### PR TITLE
Файлы при записывании в кеш не могут считаться

### DIFF
--- a/src/PhpZip/Model/Entry/ZipSourceEntry.php
+++ b/src/PhpZip/Model/Entry/ZipSourceEntry.php
@@ -66,12 +66,13 @@ class ZipSourceEntry extends ZipAbstractEntry
             if ($this->getSize() < self::MAX_SIZE_CACHED_CONTENT_IN_MEMORY) {
                 $this->entryContent = $content;
             } else {
-                $this->entryContent = fopen('php://temp', 'rb');
+                $this->entryContent = fopen('php://temp', 'r+b');
                 fwrite($this->entryContent, $content);
             }
             return $content;
         }
         if (is_resource($this->entryContent)) {
+            rewind($this->entryContent);
             return stream_get_contents($this->entryContent, -1, 0);
         }
         return $this->entryContent;


### PR DESCRIPTION
Привет! Спасибо за такой прекрасный модуль для работы с архивами!
Нашел такой глюк. При превышении размера 524288 файлы записывается в php://temp. При запросе данных из кеша stream_get_contents ничего не выводит. В fopen mode поменял на r+b, что включился режим записи. При запросе данных из stream нужно установить указатель в начало файла, поэтому перед ним вставил функцию rewind($this->entryContent);