### PR TITLE
Rewording some exceptions messages

### DIFF
--- a/src/PhpZip/ZipFile.php
+++ b/src/PhpZip/ZipFile.php
@@ -98,7 +98,7 @@ class ZipFile implements ZipFileInterface
     public function openFile($filename)
     {
         if (!file_exists($filename)) {
-            throw new InvalidArgumentException("File $filename can't exists.");
+            throw new InvalidArgumentException("File $filename does not exist.");
         }
         if (!($handle = @fopen($filename, 'rb'))) {
             throw new ZipException("File $filename can't open.");
@@ -550,10 +550,10 @@ class ZipFile implements ZipFileInterface
     {
         $inputDir = (string)$inputDir;
         if (null === $inputDir || strlen($inputDir) === 0) {
-            throw new InvalidArgumentException('Input dir empty');
+            throw new InvalidArgumentException('The input directory is not specified');
         }
         if (!is_dir($inputDir)) {
-            throw new InvalidArgumentException('Directory ' . $inputDir . ' can\'t exists');
+            throw new InvalidArgumentException(sprintf('The "%s" directory does not exist.',  $inputDir));
         }
         $inputDir = rtrim($inputDir, '/\\') . DIRECTORY_SEPARATOR;
 
@@ -580,10 +580,10 @@ class ZipFile implements ZipFileInterface
     {
         $inputDir = (string)$inputDir;
         if (null === $inputDir || strlen($inputDir) === 0) {
-            throw new InvalidArgumentException('Input dir empty');
+            throw new InvalidArgumentException('The input directory is not specified');
         }
         if (!is_dir($inputDir)) {
-            throw new InvalidArgumentException('Directory ' . $inputDir . ' can\'t exists');
+            throw new InvalidArgumentException(sprintf('The "%s" directory does not exist.',  $inputDir));
         }
         $inputDir = rtrim($inputDir, '/\\') . DIRECTORY_SEPARATOR;
 
@@ -697,14 +697,14 @@ class ZipFile implements ZipFileInterface
     ) {
         $inputDir = (string)$inputDir;
         if (null === $inputDir || 0 === strlen($inputDir)) {
-            throw new InvalidArgumentException('Input dir empty');
+            throw new InvalidArgumentException('The input directory is not specified');
         }
         if (!is_dir($inputDir)) {
-            throw new InvalidArgumentException('Directory ' . $inputDir . ' can\'t exists');
+            throw new InvalidArgumentException(sprintf('The "%s" directory does not exist.',  $inputDir));
         }
         $globPattern = (string)$globPattern;
         if (empty($globPattern)) {
-            throw new InvalidArgumentException("glob pattern empty");
+            throw new InvalidArgumentException('The glob pattern is not specified');
         }
 
         $inputDir = rtrim($inputDir, '/\\') . DIRECTORY_SEPARATOR;
@@ -792,14 +792,14 @@ class ZipFile implements ZipFileInterface
     ) {
         $regexPattern = (string)$regexPattern;
         if (empty($regexPattern)) {
-            throw new InvalidArgumentException("regex pattern empty");
+            throw new InvalidArgumentException('The regex pattern is not specified');
         }
         $inputDir = (string)$inputDir;
         if (null === $inputDir || 0 === strlen($inputDir)) {
-            throw new InvalidArgumentException('Input dir empty');
+            throw new InvalidArgumentException('The input directory is not specified');
         }
         if (!is_dir($inputDir)) {
-            throw new InvalidArgumentException('Directory ' . $inputDir . ' can\'t exists');
+            throw new InvalidArgumentException(sprintf('The "%s" directory does not exist.',  $inputDir));
         }
         $inputDir = rtrim($inputDir, '/\\') . DIRECTORY_SEPARATOR;
 

--- a/tests/PhpZip/ZipFileTest.php
+++ b/tests/PhpZip/ZipFileTest.php
@@ -17,7 +17,7 @@ class ZipFileTest extends ZipTestCase
 
     /**
      * @expectedException \PhpZip\Exception\InvalidArgumentException
-     * @expectedExceptionMessage can't exists
+     * @expectedExceptionMessage does not exist
      */
     public function testOpenFileCantExists()
     {
@@ -1235,7 +1235,7 @@ class ZipFileTest extends ZipTestCase
 
     /**
      * @expectedException \PhpZip\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Input dir empty
+     * @expectedExceptionMessage The input directory is not specified
      */
     public function testAddDirNullDirname()
     {
@@ -1245,7 +1245,7 @@ class ZipFileTest extends ZipTestCase
 
     /**
      * @expectedException \PhpZip\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Input dir empty
+     * @expectedExceptionMessage The input directory is not specified
      */
     public function testAddDirEmptyDirname()
     {
@@ -1255,7 +1255,7 @@ class ZipFileTest extends ZipTestCase
 
     /**
      * @expectedException \PhpZip\Exception\InvalidArgumentException
-     * @expectedExceptionMessage can't exists
+     * @expectedExceptionMessage does not exist
      */
     public function testAddDirCantExists()
     {
@@ -1265,7 +1265,7 @@ class ZipFileTest extends ZipTestCase
 
     /**
      * @expectedException \PhpZip\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Input dir empty
+     * @expectedExceptionMessage The input directory is not specified
      */
     public function testAddDirRecursiveNullDirname()
     {
@@ -1275,7 +1275,7 @@ class ZipFileTest extends ZipTestCase
 
     /**
      * @expectedException \PhpZip\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Input dir empty
+     * @expectedExceptionMessage The input directory is not specified
      */
     public function testAddDirRecursiveEmptyDirname()
     {
@@ -1285,7 +1285,7 @@ class ZipFileTest extends ZipTestCase
 
     /**
      * @expectedException \PhpZip\Exception\InvalidArgumentException
-     * @expectedExceptionMessage can't exists
+     * @expectedExceptionMessage does not exist
      */
     public function testAddDirRecursiveCantExists()
     {
@@ -1295,7 +1295,7 @@ class ZipFileTest extends ZipTestCase
 
     /**
      * @expectedException \PhpZip\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Input dir empty
+     * @expectedExceptionMessage The input directory is not specified
      */
     public function testAddFilesFromGlobNull()
     {
@@ -1305,7 +1305,7 @@ class ZipFileTest extends ZipTestCase
 
     /**
      * @expectedException \PhpZip\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Input dir empty
+     * @expectedExceptionMessage The input directory is not specified
      */
     public function testAddFilesFromGlobEmpty()
     {
@@ -1315,7 +1315,7 @@ class ZipFileTest extends ZipTestCase
 
     /**
      * @expectedException \PhpZip\Exception\InvalidArgumentException
-     * @expectedExceptionMessage can't exists
+     * @expectedExceptionMessage does not exist
      */
     public function testAddFilesFromGlobCantExists()
     {
@@ -1325,7 +1325,7 @@ class ZipFileTest extends ZipTestCase
 
     /**
      * @expectedException \PhpZip\Exception\InvalidArgumentException
-     * @expectedExceptionMessage glob pattern empty
+     * @expectedExceptionMessage The glob pattern is not specified
      */
     public function testAddFilesFromGlobNullPattern()
     {
@@ -1335,7 +1335,7 @@ class ZipFileTest extends ZipTestCase
 
     /**
      * @expectedException \PhpZip\Exception\InvalidArgumentException
-     * @expectedExceptionMessage glob pattern empty
+     * @expectedExceptionMessage The glob pattern is not specified
      */
     public function testAddFilesFromGlobEmptyPattern()
     {
@@ -1345,7 +1345,7 @@ class ZipFileTest extends ZipTestCase
 
     /**
      * @expectedException \PhpZip\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Input dir empty
+     * @expectedExceptionMessage The input directory is not specified
      */
     public function testAddFilesFromGlobRecursiveNull()
     {
@@ -1355,7 +1355,7 @@ class ZipFileTest extends ZipTestCase
 
     /**
      * @expectedException \PhpZip\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Input dir empty
+     * @expectedExceptionMessage The input directory is not specified
      */
     public function testAddFilesFromGlobRecursiveEmpty()
     {
@@ -1365,7 +1365,7 @@ class ZipFileTest extends ZipTestCase
 
     /**
      * @expectedException \PhpZip\Exception\InvalidArgumentException
-     * @expectedExceptionMessage can't exists
+     * @expectedExceptionMessage does not exist
      */
     public function testAddFilesFromGlobRecursiveCantExists()
     {
@@ -1375,7 +1375,7 @@ class ZipFileTest extends ZipTestCase
 
     /**
      * @expectedException \PhpZip\Exception\InvalidArgumentException
-     * @expectedExceptionMessage glob pattern empty
+     * @expectedExceptionMessage The glob pattern is not specified
      */
     public function testAddFilesFromGlobRecursiveNullPattern()
     {
@@ -1385,7 +1385,7 @@ class ZipFileTest extends ZipTestCase
 
     /**
      * @expectedException \PhpZip\Exception\InvalidArgumentException
-     * @expectedExceptionMessage glob pattern empty
+     * @expectedExceptionMessage The glob pattern is not specified
      */
     public function testAddFilesFromGlobRecursiveEmptyPattern()
     {
@@ -1395,7 +1395,7 @@ class ZipFileTest extends ZipTestCase
 
     /**
      * @expectedException \PhpZip\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Input dir empty
+     * @expectedExceptionMessage The input directory is not specified
      */
     public function testAddFilesFromRegexDirectoryNull()
     {
@@ -1405,7 +1405,7 @@ class ZipFileTest extends ZipTestCase
 
     /**
      * @expectedException \PhpZip\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Input dir empty
+     * @expectedExceptionMessage The input directory is not specified
      */
     public function testAddFilesFromRegexDirectoryEmpty()
     {
@@ -1415,7 +1415,7 @@ class ZipFileTest extends ZipTestCase
 
     /**
      * @expectedException \PhpZip\Exception\InvalidArgumentException
-     * @expectedExceptionMessage can't exists
+     * @expectedExceptionMessage does not exist
      */
     public function testAddFilesFromRegexCantExists()
     {
@@ -1425,7 +1425,7 @@ class ZipFileTest extends ZipTestCase
 
     /**
      * @expectedException \PhpZip\Exception\InvalidArgumentException
-     * @expectedExceptionMessage regex pattern empty
+     * @expectedExceptionMessage The regex pattern is not specified
      */
     public function testAddFilesFromRegexNullPattern()
     {
@@ -1435,7 +1435,7 @@ class ZipFileTest extends ZipTestCase
 
     /**
      * @expectedException \PhpZip\Exception\InvalidArgumentException
-     * @expectedExceptionMessage regex pattern empty
+     * @expectedExceptionMessage The regex pattern is not specified
      */
     public function testAddFilesFromRegexEmptyPattern()
     {
@@ -1445,7 +1445,7 @@ class ZipFileTest extends ZipTestCase
 
     /**
      * @expectedException \PhpZip\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Input dir empty
+     * @expectedExceptionMessage The input directory is not specified
      */
     public function testAddFilesFromRegexRecursiveDirectoryNull()
     {
@@ -1455,7 +1455,7 @@ class ZipFileTest extends ZipTestCase
 
     /**
      * @expectedException \PhpZip\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Input dir empty
+     * @expectedExceptionMessage The input directory is not specified
      */
     public function testAddFilesFromRegexRecursiveEmpty()
     {
@@ -1465,7 +1465,7 @@ class ZipFileTest extends ZipTestCase
 
     /**
      * @expectedException \PhpZip\Exception\InvalidArgumentException
-     * @expectedExceptionMessage can't exists
+     * @expectedExceptionMessage does not exist
      */
     public function testAddFilesFromRegexRecursiveCantExists()
     {
@@ -1475,7 +1475,7 @@ class ZipFileTest extends ZipTestCase
 
     /**
      * @expectedException \PhpZip\Exception\InvalidArgumentException
-     * @expectedExceptionMessage regex pattern empty
+     * @expectedExceptionMessage The regex pattern is not specified
      */
     public function testAddFilesFromRegexRecursiveNullPattern()
     {
@@ -1485,7 +1485,7 @@ class ZipFileTest extends ZipTestCase
 
     /**
      * @expectedException \PhpZip\Exception\InvalidArgumentException
-     * @expectedExceptionMessage regex pattern empty
+     * @expectedExceptionMessage The regex pattern is not specified
      */
     public function testAddFilesFromRegexRecursiveEmptyPattern()
     {


### PR DESCRIPTION
More expressive exception messages..

The "directory does not exists" messages is as Symfony's finder exceptions messages
https://github.com/symfony/finder/blob/ca27c02b7a3fef4828c998c2ff9ba7aae1641c49/Finder.php#L542-L548

I couldn't come up with better messages for the null checks messages, but for example `The input directory is not specified` looks more expressive than `Input dir empty`