### PR TITLE
Change fread for variable size reads to use stream_get_contents

### DIFF
--- a/src/PhpZip/Stream/ZipInputStream.php
+++ b/src/PhpZip/Stream/ZipInputStream.php
@@ -145,7 +145,7 @@ class ZipInputStream implements ZipInputStreamInterface
             }
             // .ZIP file comment       (variable size)
             if (0 < $data['commentLength']) {
-                $comment = fread($this->in, $data['commentLength']);
+                $comment = stream_get_contents($this->in, $data['commentLength']);
             }
             $this->preamble = $endOfCentralDirRecordPos;
             $this->postamble = $size - ftell($this->in);
@@ -314,7 +314,7 @@ class ZipInputStream implements ZipInputStreamInterface
 //        $utf8 = ($data['gpbf'] & ZipEntry::GPBF_UTF8) !== 0;
 
         // See appendix D of PKWARE's ZIP File Format Specification.
-        $name = fread($this->in, $data['fileLength']);
+        $name = stream_get_contents($this->in, $data['fileLength']);
 
         $entry = new ZipSourceEntry($this);
         $entry->setName($name);
@@ -329,10 +329,10 @@ class ZipInputStream implements ZipInputStreamInterface
         $entry->setExternalAttributes($data['rawExternalAttributes']);
         $entry->setOffset($data['lfhOff']); // must be unmapped!
         if ($data['extraLength'] > 0) {
-            $entry->setExtra(fread($this->in, $data['extraLength']));
+            $entry->setExtra(stream_get_contents($this->in, $data['extraLength']));
         }
         if ($data['commentLength'] > 0) {
-            $entry->setComment(fread($this->in, $data['commentLength']));
+            $entry->setComment(stream_get_contents($this->in, $data['commentLength']));
         }
         return $entry;
     }
@@ -383,7 +383,7 @@ class ZipInputStream implements ZipInputStreamInterface
         $compressedSize = $entry->getCompressedSize();
         $compressedSize = PHP_INT_SIZE === 4 ? sprintf('%u', $compressedSize) : $compressedSize;
         if ($compressedSize > 0) {
-            $content = fread($this->in, $compressedSize);
+            $content = stream_get_contents($this->in, $compressedSize);
         } else {
             $content = '';
         }
@@ -498,7 +498,7 @@ class ZipInputStream implements ZipInputStreamInterface
         if ($sourceExtraLength > 0) {
             // read Local File Header extra fields
             fseek($this->in, $pos + ZipEntry::LOCAL_FILE_HEADER_MIN_LEN + $nameLength, SEEK_SET);
-            $extra = fread($this->in, $sourceExtraLength);
+            $extra = stream_get_contents($this->in, $sourceExtraLength);
             $extraFieldsCollection = ExtraFieldsFactory::createExtraFieldCollections($extra, $entry);
             if (isset($extraFieldsCollection[ApkAlignmentExtraField::getHeaderId()]) && $this->zipModel->isZipAlign()) {
                 unset($extraFieldsCollection[ApkAlignmentExtraField::getHeaderId()]);


### PR DESCRIPTION
I am using PHP 7.2.11 on Ubuntu 16.04 (64-bit). Was trying to read a zip file using openFromStream from a user-defined stream (implemented as a [streamWrapper](http://php.net/manual/en/class.streamwrapper.php)) and found that extraction was failing on some (larger) files with the following error:

> gzinflate(): data error in /streamwrapper-test/vendor/nelexa/zip/src/PhpZip/Stream/ZipInputStream.php on line 449

Eventually found that this was because the compressed data that was read from the zip file was truncated, because PHP's fread only reads 8192 bytes instead of the user-specified byte count if used with a user-defined stream (specifically the fread is in ZipInputStream.php on line 386).

It appears that this behavior of fread is expected, but for some reason this does not occur with local files, only when using user-defined streams.

From https://grokbase.com/t/php/php-bugs/04bxwwwg71/30936-new-fread-from-userspace-stream-wrapper-only-reads-8192-bytes

> You should *always* be prepared to call fread() multiple times until you have read all the data. The only exception to this rule is when reading from a local file, for historical reasons.
>
> The 8192 magic number is the chunk size used internally by PHP.
>
> If you don't want to write a loop to read the data, use stream_get_contents().

Instead, using stream_get_contents will read until the number of bytes is reached, thus extracting the entire compressed data properly. I believe this problem will occur to all the parts that potentially will read more than 8192 bytes and thus the pull request changes those as well.

