### PR TITLE
Implemented setting maximum size for content to be cached

### DIFF
--- a/src/PhpZip/Model/Entry/ZipSourceEntry.php
+++ b/src/PhpZip/Model/Entry/ZipSourceEntry.php
@@ -41,6 +41,11 @@ class ZipSourceEntry extends ZipAbstractEntry
     private $maxCacheContentSize;
 
     /**
+     * @var bool
+     */
+    private $shouldCache;
+
+    /**
      * ZipSourceEntry constructor.
      * @param ZipInputStreamInterface $inputStream
      */
@@ -49,6 +54,7 @@ class ZipSourceEntry extends ZipAbstractEntry
         parent::__construct();
         $this->inputStream = $inputStream;
         $this->maxCacheContentSize = self::DEFAULT_MAX_SIZE_CACHED_CONTENT_IN_MEMORY;
+        $this->shouldCache = true;
     }
 
     /**
@@ -69,12 +75,11 @@ class ZipSourceEntry extends ZipAbstractEntry
         if ($this->entryContent === null) {
             // In order not to unpack again, we cache the content in memory or on disk
             $content = $this->inputStream->readEntryContent($this);
-            if ($this->getSize() < $this->maxCacheContentSize) {
-                $this->entryContent = $content;
-            } else {
-                $this->entryContent = fopen('php://temp', 'r+b');
-                fwrite($this->entryContent, $content);
+
+            if ($this->shouldCache) {
+                $this->cacheEntryContent($content);
             }
+
             return $content;
         }
         if (is_resource($this->entryContent)) {
@@ -86,11 +91,23 @@ class ZipSourceEntry extends ZipAbstractEntry
 
     /**
      * Sets the maximum byte size content can be to be kept in memory
-     * @param $size
+     * @param int $size
+     * @return void
      */
     public function setMaximumCacheContentSize($size)
     {
         $this->maxCacheContentSize = $size;
+    }
+
+    /**
+     * When set to TRUE to content of the entry will be cached, when FALSE it will not
+     *
+     * @param bool $shouldCache
+     * @return void
+     */
+    public function shouldCacheContent($shouldCache)
+    {
+        $this->shouldCache = $shouldCache;
     }
 
     /**
@@ -108,4 +125,21 @@ class ZipSourceEntry extends ZipAbstractEntry
             fclose($this->entryContent);
         }
     }
+
+    /**
+     * Will cache the content of the entry
+     *
+     * @param string $content
+     * @return void
+     */
+    private function cacheEntryContent($content)
+    {
+        if ($this->getSize() < $this->maxCacheContentSize) {
+            $this->entryContent = $content;
+        } else {
+            $this->entryContent = fopen('php://temp/', 'r+b');
+            fwrite($this->entryContent, $content);
+        }
+    }
+
 }

--- a/src/PhpZip/Model/Entry/ZipSourceEntry.php
+++ b/src/PhpZip/Model/Entry/ZipSourceEntry.php
@@ -17,7 +17,7 @@ class ZipSourceEntry extends ZipAbstractEntry
     /**
      * Max size cached content in memory.
      */
-    const MAX_SIZE_CACHED_CONTENT_IN_MEMORY = 524288; // 512 kb
+    const DEFAULT_MAX_SIZE_CACHED_CONTENT_IN_MEMORY = 524288; // 512 kb
     /**
      * @var ZipInputStreamInterface
      */
@@ -36,6 +36,11 @@ class ZipSourceEntry extends ZipAbstractEntry
     private $clone = false;
 
     /**
+     * @var int
+     */
+    private $maxCacheContentSize;
+
+    /**
      * ZipSourceEntry constructor.
      * @param ZipInputStreamInterface $inputStream
      */
@@ -43,6 +48,7 @@ class ZipSourceEntry extends ZipAbstractEntry
     {
         parent::__construct();
         $this->inputStream = $inputStream;
+        $this->maxCacheContentSize = self::DEFAULT_MAX_SIZE_CACHED_CONTENT_IN_MEMORY;
     }
 
     /**
@@ -63,7 +69,7 @@ class ZipSourceEntry extends ZipAbstractEntry
         if ($this->entryContent === null) {
             // In order not to unpack again, we cache the content in memory or on disk
             $content = $this->inputStream->readEntryContent($this);
-            if ($this->getSize() < self::MAX_SIZE_CACHED_CONTENT_IN_MEMORY) {
+            if ($this->getSize() < $this->maxCacheContentSize) {
                 $this->entryContent = $content;
             } else {
                 $this->entryContent = fopen('php://temp', 'r+b');
@@ -76,6 +82,15 @@ class ZipSourceEntry extends ZipAbstractEntry
             return stream_get_contents($this->entryContent);
         }
         return $this->entryContent;
+    }
+
+    /**
+     * Sets the maximum byte size content can be to be kept in memory
+     * @param $size
+     */
+    public function setMaximumCacheContentSize($size)
+    {
+        $this->maxCacheContentSize = $size;
     }
 
     /**

--- a/src/PhpZip/Stream/ZipInputStream.php
+++ b/src/PhpZip/Stream/ZipInputStream.php
@@ -34,6 +34,7 @@ use PhpZip\ZipFileInterface;
 class ZipInputStream implements ZipInputStreamInterface
 {
     const MAX_CACHED_ENTRY_SIZE = 'max_cached_entry_size';
+    const SHOULD_CACHE_ENTRY_CONTENT = 'cache_entry_content';
 
     /**
      * @var resource
@@ -355,6 +356,11 @@ class ZipInputStream implements ZipInputStreamInterface
         $entry->setSize($data['rawSize']);
         $entry->setExternalAttributes($data['rawExternalAttributes']);
         $entry->setOffset($data['lfhOff']); // must be unmapped!
+
+        if (($shouldCacheEntryContent = OptionsUtil::byKey(self::SHOULD_CACHE_ENTRY_CONTENT, $this->options)) !== null
+            && is_bool($shouldCacheEntryContent)) {
+            $entry->shouldCacheContent($shouldCacheEntryContent);
+        }
 
         if (($maxEntrySize = OptionsUtil::byKey(self::MAX_CACHED_ENTRY_SIZE, $this->options)) !== null) {
             $entry->setMaximumCacheContentSize($maxEntrySize);

--- a/src/PhpZip/Util/OptionsUtil.php
+++ b/src/PhpZip/Util/OptionsUtil.php
@@ -1,0 +1,21 @@
+<?php
+namespace PhpZip\Util;
+
+class OptionsUtil
+{
+
+    /**
+     * @param $key
+     * @param $options
+     * @return null
+     */
+    public static function byKey($key, $options)
+    {
+        if (!array_key_exists($key, $options)) {
+            return null;
+        }
+
+        return $options[$key];
+    }
+
+}

--- a/src/PhpZip/ZipFile.php
+++ b/src/PhpZip/ZipFile.php
@@ -17,6 +17,7 @@ use PhpZip\Stream\ZipInputStream;
 use PhpZip\Stream\ZipInputStreamInterface;
 use PhpZip\Stream\ZipOutputStream;
 use PhpZip\Util\FilesUtil;
+use PhpZip\Util\OptionsUtil;
 use PhpZip\Util\StringUtil;
 use Psr\Http\Message\ResponseInterface;
 
@@ -34,6 +35,8 @@ use Psr\Http\Message\ResponseInterface;
  */
 class ZipFile implements ZipFileInterface
 {
+    const OPTIONS_INPUT_STREAM = 'input_stream';
+
     /**
      * @var int[] Allow compression methods.
      */
@@ -75,10 +78,19 @@ class ZipFile implements ZipFileInterface
     protected $zipModel;
 
     /**
+     * @var array
+     */
+    protected $options;
+
+    /**
      * ZipFile constructor.
      */
-    public function __construct()
+    public function __construct($options = [])
     {
+        if (!is_array($options)) {
+            $options = [];
+        }
+        $this->options = $options;
         $this->zipModel = new ZipModel();
     }
 
@@ -145,7 +157,8 @@ class ZipFile implements ZipFileInterface
         if (!$meta['seekable']) {
             throw new InvalidArgumentException("Resource cannot seekable stream.");
         }
-        $this->inputStream = new ZipInputStream($handle);
+        $inputStreamOptions = OptionsUtil::byKey(self::OPTIONS_INPUT_STREAM, $this->options);
+        $this->inputStream = new ZipInputStream($handle, $inputStreamOptions);
         $this->zipModel = $this->inputStream->readZip();
         return $this;
     }

--- a/tests/PhpZip/ZipFileTest.php
+++ b/tests/PhpZip/ZipFileTest.php
@@ -2143,7 +2143,7 @@ class ZipFileTest extends ZipTestCase
      * @throws ZipException
      * @throws \ReflectionException
      */
-    public function testExtractingGettingContentWithoutCaching()
+    public function testExtractingGettingContentWithoutCachingInMemory()
     {
         $zipFile = new ZipFile();
         $zipFile['file'] = 'content';
@@ -2167,6 +2167,37 @@ class ZipFileTest extends ZipTestCase
 
         $this->assertSame('content', $content);
         $this->assertInternalType('resource', $entryContent);
+    }
+
+    /**
+     * Testing of entry contents can get get without caching data
+     * @throws ZipException
+     * @throws \ReflectionException
+     */
+    public function testExtractingGettingContentWithoutCaching()
+    {
+        $zipFile = new ZipFile();
+        $zipFile['file'] = 'content';
+        $zipFile->saveAsFile($this->outputFilename);
+        $zipFile->close();
+
+        $extractingZip = new ZipFile([
+            ZipFile::OPTIONS_INPUT_STREAM => [
+                ZipInputStream::SHOULD_CACHE_ENTRY_CONTENT => false
+            ]
+        ]);
+        $extractingZip->openFile($this->outputFilename);
+        $content = $extractingZip->getEntryContents('file');
+
+        /** @var ZipModel $zipModel */
+        $zipModel = $this->getPropertyThroughReflection($extractingZip, 'zipModel');
+        $entry = $zipModel->getEntry('file');
+        $entryContent = $this->getPropertyThroughReflection($entry, 'entryContent');
+
+        $extractingZip->close();
+
+        $this->assertSame('content', $content);
+        $this->assertNull($entryContent);
     }
 
     /**


### PR DESCRIPTION
Possible fix for #27 

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no

When a zip file containing a lot of small files, less than 512k, the
ZipFile will crash due to caching all of the content in memory. Fixed this
by adding options to be passed along the zip file object to set the memory
threshold. When set to 0 it will not cache file contents and not fail the
memory limit.
