### PR TITLE
Do not pin random_compat version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": "^5.5.9 || ^7.0",
         "ext-zlib": "*",
         "psr/http-message": "^1.0",
-        "paragonie/random_compat": ">=1 <9.99",
+        "paragonie/random_compat": "*",
         "symfony/finder": "^3.0|^4.0|^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no

The strange 9.99.99 version is an empty package for PHP 7 only (which by now should be default) and one of my packages pins random_compat there thus conflicting with php-zip. No reason to exclude that version AFAIK.