### PR TITLE
Make zlib optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
     ],
     "require": {
         "php": "^5.5.9 || ^7.0",
-        "ext-zlib": "*",
         "psr/http-message": "^1.0",
         "paragonie/random_compat": "*",
         "symfony/finder": "^3.0|^4.0|^5.0"
     },
     "require-dev": {
+        "ext-zlib": "*",
         "ext-bz2": "*",
         "ext-openssl": "*",
         "ext-fileinfo": "*",

--- a/src/Util/FilesUtil.php
+++ b/src/Util/FilesUtil.php
@@ -2,6 +2,7 @@
 
 namespace PhpZip\Util;
 
+use PhpZip\Constants\ZipCompressionMethod;
 use PhpZip\Util\Iterator\IgnoreFilesFilterIterator;
 use PhpZip\Util\Iterator\IgnoreFilesRecursiveFilterIterator;
 
@@ -317,6 +318,22 @@ final class FilesUtil
         }
 
         return symlink($target, $path);
+    }
+
+    /**
+     * @param bool $deflateCompatible
+     *
+     * @return int
+     */
+    public static function getDefaultCompressionMethod($deflateCompatible)
+    {
+      if (!$deflateCompatible) {
+          return ZipCompressionMethod::STORED;
+      }
+      if (!extension_loaded('zlib')) {
+          return ZipCompressionMethod::STORED;
+      }
+      return ZipCompressionMethod::DEFLATED;
     }
 
     /**

--- a/src/ZipFile.php
+++ b/src/ZipFile.php
@@ -576,9 +576,7 @@ class ZipFile implements ZipFileInterface
                 $compressionMethod = ZipCompressionMethod::STORED;
             } else {
                 $mimeType = FilesUtil::getMimeTypeFromString($contents);
-                $compressionMethod = FilesUtil::isBadCompressionMimeType($mimeType) ?
-                    ZipCompressionMethod::STORED :
-                    ZipCompressionMethod::DEFLATED;
+                $compressionMethod = FilesUtil::getDefaultCompressionMethod(!FilesUtil::isBadCompressionMimeType($mimeType));
             }
         }
 
@@ -714,9 +712,7 @@ class ZipFile implements ZipFileInterface
             } elseif ($file->getSize() < 512) {
                 $compressionMethod = ZipCompressionMethod::STORED;
             } else {
-                $compressionMethod = FilesUtil::isBadCompressionFile($file->getPathname()) ?
-                    ZipCompressionMethod::STORED :
-                    ZipCompressionMethod::DEFLATED;
+                $compressionMethod = FilesUtil::getDefaultCompressionMethod(!FilesUtil::isBadCompressionFile($file->getPathname()));
             }
 
             $zipEntry->setCompressionMethod($compressionMethod);
@@ -838,9 +834,7 @@ class ZipFile implements ZipFileInterface
                     $bufferContents = stream_get_contents($stream, min(1024, $length));
                     rewind($stream);
                     $mimeType = FilesUtil::getMimeTypeFromString($bufferContents);
-                    $compressionMethod = FilesUtil::isBadCompressionMimeType($mimeType) ?
-                        ZipCompressionMethod::STORED :
-                        ZipCompressionMethod::DEFLATED;
+                    $compressionMethod = FilesUtil::getDefaultCompressionMethod(!FilesUtil::isBadCompressionMimeType($mimeType));
                 }
                 $zipEntry->setUncompressedSize($length);
             }
@@ -848,7 +842,7 @@ class ZipFile implements ZipFileInterface
             $unixMode = 0100644;
 
             if ($compressionMethod === null || $compressionMethod === ZipEntry::UNKNOWN) {
-                $compressionMethod = ZipCompressionMethod::DEFLATED;
+                $compressionMethod = FilesUtil::getDefaultCompressionMethod(true);
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

The composer.json currently has a dependency on ext-zlib, however this project is useful without it, if you use ZipCompressionMethod::STORED for all files, you can still do useful things like create archive, password protect them.

This change moves the decision about which format to automatically use behind a method on FileUtils that also does the extension loaded check
