### PR TITLE
Allow PHP 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": "^5.5.9 || ^7.0",
+        "php": "^5.5.9 || ^7.0 || ^8.0",
         "ext-zlib": "*",
         "psr/http-message": "^1.0",
         "paragonie/random_compat": "*",


### PR DESCRIPTION
Stops check for PHP major version from preventing installation via composer on projects using PHP 8.x. 

Note this commit is just removing the restriction. All features have not been re-tested on PHP 8.x

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no 
