### PR TITLE
Add PHP 8 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,48 @@
+name: build
+
+on: [ push, pull_request ]
+
+jobs:
+  run:
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest]
+        php-versions: ['7.3', '7.4', '8.0']
+    name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring, intl, zip
+          coverage: none
+
+      - name: Check PHP Version
+        run: php -v
+
+      - name: Check Composer Version
+        run: composer -V
+
+      - name: Check PHP Extensions
+        run: php -m
+
+      - name: Validate composer.json and composer.lock
+        run: composer validate
+
+      - name: Install dependencies for PHP 7
+        if: matrix.php-versions < '8.0'
+        run: composer update --prefer-dist --no-progress
+
+      - name: Install dependencies for PHP 8
+        if: matrix.php-versions >= '8.0'
+        run: composer update --prefer-dist --no-progress --ignore-platform-req=php
+
+      - name: Run test suite
+        run: composer check
+        env:
+          PHP_CS_FIXER_IGNORE_ENV: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.3', '7.4', '8.0']
+        php-versions: ['7.2', '7.3', '7.4', '8.0']
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /.idea
 /composer.lock
 /*.cache
+build/
+.phpunit.result.cache

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,43 @@
+filter:
+  paths: ["src/*"]
+  excluded_paths: ["vendor/*", "tests/*"]
+
+checks:
+  php:
+    code_rating: true
+    duplication: true
+
+tools:
+  external_code_coverage: false
+
+build:
+  environment:
+    php:
+      version: 7.4
+      pecl_extensions:
+        - zip
+    mysql: false
+    node: false
+    postgresql: false
+    mongodb: false
+    elasticsearch: false
+    redis: false
+    memcached: false
+    neo4j: false
+    rabbitmq: false
+  nodes:
+    analysis:
+      tests:
+        override:
+          - php-scrutinizer-run
+  dependencies:
+    before:
+      - composer self-update
+      - composer update --no-interaction --prefer-dist --no-progress
+  tests:
+    before:
+      -
+        command: composer test:coverage
+        coverage:
+          file: 'build/logs/clover.xml'
+          format: 'clover'

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ========
 `PhpZip` is a php-library for extended work with ZIP-archives.
 
-[![Build Status](https://travis-ci.org/Ne-Lexa/php-zip.svg?branch=master)](https://travis-ci.org/Ne-Lexa/php-zip)
+[![Build Status](https://github.com/Ne-Lexa/php-zip/workflows/build/badge.svg)](https://github.com/Ne-Lexa/php-zip/actions)
 [![Code Coverage](https://scrutinizer-ci.com/g/Ne-Lexa/php-zip/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/Ne-Lexa/php-zip/?branch=master)
 [![Latest Stable Version](https://poser.pugx.org/nelexa/zip/v/stable)](https://packagist.org/packages/nelexa/zip)
 [![Total Downloads](https://poser.pugx.org/nelexa/zip/downloads)](https://packagist.org/packages/nelexa/zip)
@@ -66,7 +66,7 @@ Table of contents
   + Set the encryption method for all or individual entries in the archive.
 
 ### <a name="Requirements"></a> Requirements
-- `PHP` >= 5.5 (preferably 64-bit).
+- `PHP` >= 7.2 or `PHP` >= 8.0 (preferably 64-bit).
 - Optional php-extension `bzip2` for BZIP2 compression.
 - Optional php-extension `openssl` or `mcrypt` for `WinZip Aes Encryption` support.
 

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
         }
     ],
     "require": {
-        "php": "^5.5.9 || ^7.0",
+        "php": "^7.2 || ^8.0",
         "ext-zlib": "*",
         "psr/http-message": "^1.0",
         "paragonie/random_compat": "*",
-        "symfony/finder": "^3.0|^4.0|^5.0"
+        "symfony/finder": "^3.0 || ^4.0 || ^5.0"
     },
     "require-dev": {
         "ext-bz2": "*",
@@ -33,8 +33,8 @@
         "ext-fileinfo": "*",
         "ext-xml": "*",
         "guzzlehttp/psr7": "^1.6",
-        "phpunit/phpunit": "^4.8|^5.7",
-        "symfony/var-dumper": "^3.0|^4.0|^5.0"
+        "phpunit/phpunit": "^8 || ^9",
+        "symfony/var-dumper": "^5.0"
     },
     "autoload": {
         "psr-4": {
@@ -55,6 +55,7 @@
     "minimum-stability": "stable",
     "scripts": {
         "php:fix": "php .php_cs --force",
-        "php:fix:debug": "php .php_cs"
+        "test": "phpunit --configuration phpunit.xml --do-not-cache-result --colors=always",
+        "test:coverage": "phpunit --configuration phpunit.xml --do-not-cache-result --colors=always --coverage-clover build/logs/clover.xml --coverage-html build/coverage"
     }
 }

--- a/tests/Extra/Fields/AbstractUnicodeExtraFieldTest.php
+++ b/tests/Extra/Fields/AbstractUnicodeExtraFieldTest.php
@@ -76,7 +76,7 @@ abstract class AbstractUnicodeExtraFieldTest extends TestCase
      */
     public function testUnicodeErrorParse()
     {
-        $this->setExpectedException(
+        $this->expectException(
             ZipException::class,
             'Unicode path extra data must have at least 5 bytes.'
         );
@@ -90,7 +90,7 @@ abstract class AbstractUnicodeExtraFieldTest extends TestCase
      */
     public function testUnknownVersionParse()
     {
-        $this->setExpectedException(
+        $this->expectException(
             ZipException::class,
             'Unsupported version [2] for Unicode path extra data.'
         );

--- a/tests/Extra/Fields/ApkAlignmentExtraFieldTest.php
+++ b/tests/Extra/Fields/ApkAlignmentExtraFieldTest.php
@@ -96,7 +96,6 @@ final class ApkAlignmentExtraFieldTest extends TestCase
      */
     public function testInvalidParse()
     {
-        //$this->expectException(
         $this->expectException(
             ZipException::class,
             'Minimum 6 bytes of the extensible data block/field used for alignment of uncompressed entries.'

--- a/tests/Extra/Fields/ApkAlignmentExtraFieldTest.php
+++ b/tests/Extra/Fields/ApkAlignmentExtraFieldTest.php
@@ -96,7 +96,8 @@ final class ApkAlignmentExtraFieldTest extends TestCase
      */
     public function testInvalidParse()
     {
-        $this->setExpectedException(
+        //$this->expectException(
+        $this->expectException(
             ZipException::class,
             'Minimum 6 bytes of the extensible data block/field used for alignment of uncompressed entries.'
         );

--- a/tests/Extra/Fields/AsiExtraFieldTest.php
+++ b/tests/Extra/Fields/AsiExtraFieldTest.php
@@ -91,7 +91,7 @@ final class AsiExtraFieldTest extends TestCase
      */
     public function testInvalidParse()
     {
-        $this->setExpectedException(
+        $this->expectException(
             Crc32Exception::class,
             'Asi Unix Extra Filed Data (expected CRC32 value'
         );

--- a/tests/Extra/Fields/JarMarkerExtraFieldTest.php
+++ b/tests/Extra/Fields/JarMarkerExtraFieldTest.php
@@ -32,7 +32,7 @@ final class JarMarkerExtraFieldTest extends TestCase
      */
     public function testInvalidUnpackLocalData()
     {
-        $this->setExpectedException(
+        $this->expectException(
             ZipException::class,
             "JarMarker doesn't expect any data"
         );
@@ -45,7 +45,7 @@ final class JarMarkerExtraFieldTest extends TestCase
      */
     public function testInvalidUnpackCdData()
     {
-        $this->setExpectedException(
+        $this->expectException(
             ZipException::class,
             "JarMarker doesn't expect any data"
         );

--- a/tests/Extra/Fields/NtfsExtraFieldTest.php
+++ b/tests/Extra/Fields/NtfsExtraFieldTest.php
@@ -14,7 +14,7 @@ use PhpZip\Model\Extra\Fields\NtfsExtraField;
  */
 final class NtfsExtraFieldTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         if (\PHP_INT_SIZE === 4) {
             self::markTestSkipped('only 64 bit test');

--- a/tests/Extra/Fields/UnrecognizedExtraFieldTest.php
+++ b/tests/Extra/Fields/UnrecognizedExtraFieldTest.php
@@ -37,7 +37,7 @@ final class UnrecognizedExtraFieldTest extends TestCase
 
     public function testUnpackLocalData()
     {
-        $this->setExpectedException(
+        $this->expectException(
             RuntimeException::class,
             'Unsupport parse'
         );
@@ -47,7 +47,7 @@ final class UnrecognizedExtraFieldTest extends TestCase
 
     public function testUnpackCentralDirData()
     {
-        $this->setExpectedException(
+        $this->expectException(
             RuntimeException::class,
             'Unsupport parse'
         );

--- a/tests/Extra/Fields/WinZipAesExtraFieldTest.php
+++ b/tests/Extra/Fields/WinZipAesExtraFieldTest.php
@@ -157,7 +157,7 @@ final class WinZipAesExtraFieldTest extends TestCase
      */
     public function testConstructUnsupportVendorVersion()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Unsupport WinZip AES vendor version: 3');
+        $this->expectException(InvalidArgumentException::class, 'Unsupport WinZip AES vendor version: 3');
 
         new WinZipAesExtraField(
             3,
@@ -171,7 +171,7 @@ final class WinZipAesExtraFieldTest extends TestCase
      */
     public function testSetterUnsupportVendorVersion()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Unsupport WinZip AES vendor version: 3');
+        $this->expectException(InvalidArgumentException::class, 'Unsupport WinZip AES vendor version: 3');
 
         $extraField = new WinZipAesExtraField(
             WinZipAesExtraField::VERSION_AE1,
@@ -186,7 +186,7 @@ final class WinZipAesExtraFieldTest extends TestCase
      */
     public function testConstructUnsupportCompressionMethod()
     {
-        $this->setExpectedException(ZipUnsupportMethodException::class, 'Compression method 3 (Reduced compression factor 2) is not supported.');
+        $this->expectException(ZipUnsupportMethodException::class, 'Compression method 3 (Reduced compression factor 2) is not supported.');
 
         new WinZipAesExtraField(
             WinZipAesExtraField::VERSION_AE1,
@@ -200,7 +200,7 @@ final class WinZipAesExtraFieldTest extends TestCase
      */
     public function testSetterUnsupportCompressionMethod()
     {
-        $this->setExpectedException(ZipUnsupportMethodException::class, 'Compression method 3 (Reduced compression factor 2) is not supported.');
+        $this->expectException(ZipUnsupportMethodException::class, 'Compression method 3 (Reduced compression factor 2) is not supported.');
 
         $extraField = new WinZipAesExtraField(
             WinZipAesExtraField::VERSION_AE1,
@@ -215,7 +215,7 @@ final class WinZipAesExtraFieldTest extends TestCase
      */
     public function testConstructUnsupportKeyStrength()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Key strength 16 not support value. Allow values: 1, 2, 3');
+        $this->expectException(InvalidArgumentException::class, 'Key strength 16 not support value. Allow values: 1, 2, 3');
 
         new WinZipAesExtraField(
             WinZipAesExtraField::VERSION_AE1,
@@ -229,7 +229,7 @@ final class WinZipAesExtraFieldTest extends TestCase
      */
     public function testSetterUnsupportKeyStrength()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Key strength 16 not support value. Allow values: 1, 2, 3');
+        $this->expectException(InvalidArgumentException::class, 'Key strength 16 not support value. Allow values: 1, 2, 3');
 
         new WinZipAesExtraField(
             WinZipAesExtraField::VERSION_AE1,

--- a/tests/Extra/Fields/Zip64ExtraFieldTest.php
+++ b/tests/Extra/Fields/Zip64ExtraFieldTest.php
@@ -15,7 +15,7 @@ use PhpZip\Model\ZipEntry;
  */
 final class Zip64ExtraFieldTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         if (\PHP_INT_SIZE === 4) {
             self::markTestSkipped('only 64 bit test');

--- a/tests/Issue24Test.php
+++ b/tests/Issue24Test.php
@@ -21,7 +21,7 @@ class Issue24Test extends ZipTestCase
      *
      * @noinspection PhpMissingParentCallCommonInspection
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         stream_wrapper_register(self::PROTO_DUMMYFS, DummyFileSystemStream::class);
     }

--- a/tests/PhpZipExtResourceTest.php
+++ b/tests/PhpZipExtResourceTest.php
@@ -109,7 +109,7 @@ class PhpZipExtResourceTest extends ZipTestCase
      */
     public function testBug49072()
     {
-        $this->setExpectedException(Crc32Exception::class, 'file1');
+        $this->expectException(Crc32Exception::class, 'file1');
 
         $filename = __DIR__ . '/resources/pecl/bug49072.zip';
 
@@ -128,12 +128,12 @@ class PhpZipExtResourceTest extends ZipTestCase
     public function testBug70752()
     {
         if (\PHP_INT_SIZE === 4) { // php 32 bit
-            $this->setExpectedException(
+            $this->expectException(
                 RuntimeException::class,
                 'Traditional PKWARE Encryption is not supported in 32-bit PHP.'
             );
         } else { // php 64 bit
-            $this->setExpectedException(
+            $this->expectException(
                 ZipAuthenticationException::class,
                 'Invalid password'
             );
@@ -151,7 +151,7 @@ class PhpZipExtResourceTest extends ZipTestCase
             $zipFile->extractTo($this->outputDirname);
             static::markTestIncomplete('failed test');
         } catch (ZipException $exception) {
-            static::assertFileNotExists($this->outputDirname . '/bug70752.txt');
+            static::assertFileDoesNotExist($this->outputDirname . '/bug70752.txt');
 
             throw $exception;
         } finally {
@@ -168,7 +168,7 @@ class PhpZipExtResourceTest extends ZipTestCase
      */
     public function testPecl12414()
     {
-        $this->setExpectedException(ZipException::class, 'Corrupt zip file. Cannot read zip entry.');
+        $this->expectException(ZipException::class, 'Corrupt zip file. Cannot read zip entry.');
 
         $filename = __DIR__ . '/resources/pecl/pecl12414.zip';
 

--- a/tests/ZipEntryTest.php
+++ b/tests/ZipEntryTest.php
@@ -89,7 +89,7 @@ class ZipEntryTest extends TestCase
      */
     public function testEmptyName($entryName, $exceptionMessage)
     {
-        $this->setExpectedException(InvalidArgumentException::class, $exceptionMessage);
+        $this->expectException(InvalidArgumentException::class, $exceptionMessage);
 
         new ZipEntry($entryName);
     }
@@ -174,7 +174,7 @@ class ZipEntryTest extends TestCase
      */
     public function testOutOfRangeCompressionMethod($compressionMethod)
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'method out of range: ' . $compressionMethod);
+        $this->expectException(InvalidArgumentException::class, 'method out of range: ' . $compressionMethod);
 
         $zipEntry = new ZipEntry('entry');
         $zipEntry->setCompressionMethod($compressionMethod);
@@ -201,7 +201,7 @@ class ZipEntryTest extends TestCase
      */
     public function testUnsupportCompressionMethod($compressionMethod, $exceptionMessage)
     {
-        $this->setExpectedException(ZipUnsupportMethodException::class, $exceptionMessage);
+        $this->expectException(ZipUnsupportMethodException::class, $exceptionMessage);
 
         $zipEntry = new ZipEntry('entry');
         $zipEntry->setCompressionMethod($compressionMethod);
@@ -253,7 +253,7 @@ class ZipEntryTest extends TestCase
 
     public function testEmptyCharset()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Empty charset');
+        $this->expectException(InvalidArgumentException::class, 'Empty charset');
 
         $zipEntry = new ZipEntry('entry');
         $zipEntry->setCharset('');
@@ -398,7 +398,7 @@ class ZipEntryTest extends TestCase
      */
     public function testInvalidCreatedOs($zipOS)
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Platform out of range');
+        $this->expectException(InvalidArgumentException::class, 'Platform out of range');
 
         $zipEntry = new ZipEntry('entry');
         $zipEntry->setCreatedOS($zipOS);
@@ -422,7 +422,7 @@ class ZipEntryTest extends TestCase
      */
     public function testInvalidExtractedOs($zipOS)
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Platform out of range');
+        $this->expectException(InvalidArgumentException::class, 'Platform out of range');
 
         $zipEntry = new ZipEntry('entry');
         $zipEntry->setExtractedOS($zipOS);
@@ -545,7 +545,7 @@ class ZipEntryTest extends TestCase
 
     public function testInvalidCompressedSize()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Compressed size < -1');
+        $this->expectException(InvalidArgumentException::class, 'Compressed size < -1');
 
         $zipEntry = new ZipEntry('entry');
         $zipEntry->setCompressedSize(-2);
@@ -553,7 +553,7 @@ class ZipEntryTest extends TestCase
 
     public function testInvalidUncompressedSize()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Uncompressed size < -1');
+        $this->expectException(InvalidArgumentException::class, 'Uncompressed size < -1');
 
         $zipEntry = new ZipEntry('entry');
         $zipEntry->setUncompressedSize(-2);
@@ -568,7 +568,7 @@ class ZipEntryTest extends TestCase
         $zipEntry->setLocalHeaderOffset($localHeaderOffset);
         static::assertSame($zipEntry->getLocalHeaderOffset(), $localHeaderOffset);
 
-        $this->setExpectedException(InvalidArgumentException::class, 'Negative $localHeaderOffset');
+        $this->expectException(InvalidArgumentException::class, 'Negative $localHeaderOffset');
         $zipEntry->setLocalHeaderOffset(-1);
     }
 
@@ -652,7 +652,7 @@ class ZipEntryTest extends TestCase
      */
     public function testInvalidGPBF($gpbf)
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'general purpose bit flags out of range');
+        $this->expectException(InvalidArgumentException::class, 'general purpose bit flags out of range');
 
         $zipEntry = new ZipEntry('entry');
         $zipEntry->setGeneralPurposeBitFlags($gpbf);
@@ -791,7 +791,7 @@ class ZipEntryTest extends TestCase
      */
     public function testInvalidCompressionLevel($compressionLevel)
     {
-        $this->setExpectedException(
+        $this->expectException(
             InvalidArgumentException::class,
             'Invalid compression level. Minimum level ' . ZipCompressionLevel::LEVEL_MIN .
             '. Maximum level ' . ZipCompressionLevel::LEVEL_MAX
@@ -855,7 +855,7 @@ class ZipEntryTest extends TestCase
             return;
         }
 
-        $this->setExpectedException(InvalidArgumentException::class, 'DosTime out of range');
+        $this->expectException(InvalidArgumentException::class, 'DosTime out of range');
 
         $zipEntry = new ZipEntry('entry');
         $zipEntry->setDosTime($dosTime);
@@ -1012,7 +1012,7 @@ class ZipEntryTest extends TestCase
             return;
         }
 
-        $this->setExpectedException(InvalidArgumentException::class, 'external attributes out of range');
+        $this->expectException(InvalidArgumentException::class, 'external attributes out of range');
 
         $zipEntry = new ZipEntry('entry');
         $zipEntry->setExternalAttributes($externalAttributes);
@@ -1045,7 +1045,7 @@ class ZipEntryTest extends TestCase
      */
     public function testInvalidInternalAttributes($internalAttributes)
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'internal attributes out of range');
+        $this->expectException(InvalidArgumentException::class, 'internal attributes out of range');
 
         $zipEntry = new ZipEntry('entry');
         $zipEntry->setInternalAttributes($internalAttributes);
@@ -1140,7 +1140,7 @@ class ZipEntryTest extends TestCase
      */
     public function testLongComment()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Comment too long');
+        $this->expectException(InvalidArgumentException::class, 'Comment too long');
 
         $longComment = random_bytes(0xffff + 1);
         $zipEntry = new ZipEntry('entry');
@@ -1305,7 +1305,7 @@ class ZipEntryTest extends TestCase
      */
     public function testInvalidEncryptionMethod($encryptionMethod)
     {
-        $this->setExpectedException(
+        $this->expectException(
             InvalidArgumentException::class,
             'Encryption method ' . $encryptionMethod . ' is not supported.'
         );

--- a/tests/ZipFileSetTestCase.php
+++ b/tests/ZipFileSetTestCase.php
@@ -30,7 +30,7 @@ abstract class ZipFileSetTestCase extends ZipTestCase
     /**
      * Before test.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->fillDirectory();

--- a/tests/ZipFileTest.php
+++ b/tests/ZipFileTest.php
@@ -31,7 +31,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testOpenFileCantExists()
     {
-        $this->setExpectedException(ZipException::class, 'does not exist');
+        $this->expectException(ZipException::class, 'does not exist');
 
         $zipFile = new ZipFile();
         $zipFile->openFile(uniqid('', false));
@@ -50,7 +50,7 @@ class ZipFileTest extends ZipTestCase
             return;
         }
 
-        $this->setExpectedException(ZipException::class, 'can\'t open');
+        $this->expectException(ZipException::class, 'can\'t open');
 
         static::assertNotFalse(file_put_contents($this->outputFilename, 'content'));
         static::assertTrue(chmod($this->outputFilename, 0222));
@@ -64,7 +64,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testOpenFileEmptyFile()
     {
-        $this->setExpectedException(ZipException::class, 'Corrupt zip file');
+        $this->expectException(ZipException::class, 'Corrupt zip file');
 
         static::assertNotFalse(touch($this->outputFilename));
         $zipFile = new ZipFile();
@@ -77,7 +77,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testOpenFileInvalidZip()
     {
-        $this->setExpectedException(
+        $this->expectException(
             ZipException::class,
             'Invalid zip file. The end of the central directory could not be found.'
         );
@@ -92,7 +92,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testOpenFromStringNullString()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Empty string passed');
+        $this->expectException(InvalidArgumentException::class, 'Empty string passed');
 
         $zipFile = new ZipFile();
         $zipFile->openFromString(null);
@@ -103,7 +103,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testOpenFromStringEmptyString()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Empty string passed');
+        $this->expectException(InvalidArgumentException::class, 'Empty string passed');
 
         $zipFile = new ZipFile();
         $zipFile->openFromString('');
@@ -115,7 +115,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testOpenFromStringInvalidZip()
     {
-        $this->setExpectedException(
+        $this->expectException(
             ZipException::class,
             'Invalid zip file. The end of the central directory could not be found.'
         );
@@ -149,7 +149,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testOpenFromStreamNullStream()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Stream must be a resource');
+        $this->expectException(InvalidArgumentException::class, 'Stream must be a resource');
 
         $zipFile = new ZipFile();
         $zipFile->openFromStream(null);
@@ -160,7 +160,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testOpenFromStreamInvalidResourceType()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Stream must be a resource');
+        $this->expectException(InvalidArgumentException::class, 'Stream must be a resource');
 
         $zipFile = new ZipFile();
         /** @noinspection PhpParamsInspection */
@@ -172,7 +172,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testOpenFromStreamInvalidResourceType2()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Invalid resource type');
+        $this->expectException(InvalidArgumentException::class, 'Invalid resource type');
 
         $zipFile = new ZipFile();
 
@@ -190,7 +190,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testOpenFromStreamInvalidResourceType3()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Directory stream not supported');
+        $this->expectException(InvalidArgumentException::class, 'Directory stream not supported');
 
         $zipFile = new ZipFile();
         $zipFile->openFromStream(opendir(__DIR__));
@@ -203,7 +203,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testOpenFromStreamNoSeekable()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'The stream wrapper type "http" is not supported');
+        $this->expectException(InvalidArgumentException::class, 'The stream wrapper type "http" is not supported');
 
         if (!$fp = @fopen('http://localhost', 'rb')) {
             if (!$fp = @fopen('http://example.org', 'rb')) {
@@ -222,7 +222,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testOpenFromStreamEmptyContents()
     {
-        $this->setExpectedException(ZipException::class, 'Corrupt zip file');
+        $this->expectException(ZipException::class, 'Corrupt zip file');
 
         $fp = fopen($this->outputFilename, 'w+b');
         $zipFile = new ZipFile();
@@ -235,7 +235,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testOpenFromStreamInvalidZip()
     {
-        $this->setExpectedException(
+        $this->expectException(
             ZipException::class,
             'Invalid zip file. The end of the central directory could not be found.'
         );
@@ -508,7 +508,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testRenameEntryNull()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'name is null');
+        $this->expectException(InvalidArgumentException::class, 'name is null');
 
         $zipFile = new ZipFile();
         $zipFile->rename(null, 'new-file');
@@ -519,7 +519,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testRenameEntryNull2()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'name is null');
+        $this->expectException(InvalidArgumentException::class, 'name is null');
 
         $zipFile = new ZipFile();
         $zipFile->rename('old-file', null);
@@ -530,7 +530,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testRenameEntryToExistsNewEntry()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'is exists');
+        $this->expectException(InvalidArgumentException::class, 'is exists');
 
         $zipFile = new ZipFile();
         $zipFile['file'] = 'content';
@@ -548,7 +548,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testRenameEntryNotFound()
     {
-        $this->setExpectedException(ZipEntryNotFoundException::class);
+        $this->expectException(ZipEntryNotFoundException::class);
 
         $zipFile = new ZipFile();
         $zipFile['file'] = 'content';
@@ -615,7 +615,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testDeleteFromNameNotFoundEntry()
     {
-        $this->setExpectedException(ZipEntryNotFoundException::class);
+        $this->expectException(ZipEntryNotFoundException::class);
 
         $zipFile = new ZipFile();
         $zipFile->deleteFromName('entry');
@@ -674,7 +674,7 @@ class ZipFileTest extends ZipTestCase
 
     public function testDeleteFromGlobFailNull()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'The glob pattern is not specified');
+        $this->expectException(InvalidArgumentException::class, 'The glob pattern is not specified');
 
         $zipFile = new ZipFile();
         $zipFile->deleteFromGlob(null);
@@ -682,7 +682,7 @@ class ZipFileTest extends ZipTestCase
 
     public function testDeleteFromGlobFailEmpty()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'The glob pattern is not specified');
+        $this->expectException(InvalidArgumentException::class, 'The glob pattern is not specified');
 
         $zipFile = new ZipFile();
         $zipFile->deleteFromGlob('');
@@ -722,7 +722,7 @@ class ZipFileTest extends ZipTestCase
 
     public function testDeleteFromRegexFailNull()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'The regex pattern is not specified');
+        $this->expectException(InvalidArgumentException::class, 'The regex pattern is not specified');
 
         $zipFile = new ZipFile();
         $zipFile->deleteFromRegex(null);
@@ -730,7 +730,7 @@ class ZipFileTest extends ZipTestCase
 
     public function testDeleteFromRegexFailEmpty()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'The regex pattern is not specified');
+        $this->expectException(InvalidArgumentException::class, 'The regex pattern is not specified');
 
         $zipFile = new ZipFile();
         $zipFile->deleteFromRegex('');
@@ -806,7 +806,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testVeryLongArchiveComment()
     {
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $comment = 'Very long comment' . \PHP_EOL .
             'Очень длинный комментарий' . \PHP_EOL;
@@ -898,7 +898,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testVeryLongEntryComment()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Comment too long');
+        $this->expectException(InvalidArgumentException::class, 'Comment too long');
 
         $comment = 'Very long comment' . \PHP_EOL .
             'Очень длинный комментарий' . \PHP_EOL;
@@ -914,7 +914,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testSetEntryCommentNotFoundEntry()
     {
-        $this->setExpectedException(ZipEntryNotFoundException::class);
+        $this->expectException(ZipEntryNotFoundException::class);
 
         $zipFile = new ZipFile();
         $zipFile->setEntryComment('test', 'comment');
@@ -979,7 +979,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testSetInvalidCompressionLevel($compressionLevel)
     {
-        $this->setExpectedException(
+        $this->expectException(
             InvalidArgumentException::class,
             'Invalid compression level. Minimum level 1. Maximum level 9'
         );
@@ -1131,7 +1131,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testExtractFail()
     {
-        $this->setExpectedException(ZipException::class, 'not found');
+        $this->expectException(ZipException::class, 'not found');
 
         $zipFile = new ZipFile();
         $zipFile['file'] = 'content';
@@ -1147,7 +1147,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testExtractFail2()
     {
-        $this->setExpectedException(ZipException::class, 'Destination is not directory');
+        $this->expectException(ZipException::class, 'Destination is not directory');
 
         $zipFile = new ZipFile();
         $zipFile['file'] = 'content';
@@ -1163,7 +1163,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testExtractFail3()
     {
-        $this->setExpectedException(ZipException::class, 'Destination is not writable directory');
+        $this->expectException(ZipException::class, 'Destination is not writable directory');
 
         if (static::skipTestForRootUser()) {
             return;
@@ -1186,7 +1186,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddFromArrayAccessNullName()
     {
-        $this->setExpectedException(
+        $this->expectException(
             InvalidArgumentException::class,
             'Key must not be null, but must contain the name of the zip entry.'
         );
@@ -1200,7 +1200,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddFromArrayAccessEmptyName()
     {
-        $this->setExpectedException(
+        $this->expectException(
             InvalidArgumentException::class,
             'Key is empty, but must contain the name of the zip entry.'
         );
@@ -1214,7 +1214,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddFromStringNullContents()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Contents is null');
+        $this->expectException(InvalidArgumentException::class, 'Contents is null');
 
         $zipFile = new ZipFile();
         $zipFile->addFromString('file', null);
@@ -1225,7 +1225,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddFromStringNullEntryName()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Entry name is null');
+        $this->expectException(InvalidArgumentException::class, 'Entry name is null');
 
         $zipFile = new ZipFile();
         $zipFile->addFromString(null, 'contents');
@@ -1236,7 +1236,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddFromStringUnsupportedMethod()
     {
-        $this->setExpectedException(
+        $this->expectException(
             ZipUnsupportMethodException::class,
             'Compression method 99 (AES Encryption) is not supported.'
         );
@@ -1251,7 +1251,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddFromStringEmptyEntryName()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Empty entry name');
+        $this->expectException(InvalidArgumentException::class, 'Empty entry name');
 
         $zipFile = new ZipFile();
         $zipFile->addFromString('', 'contents');
@@ -1292,7 +1292,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddFromStreamInvalidResource()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Stream is not resource');
+        $this->expectException(InvalidArgumentException::class, 'Stream is not resource');
 
         $zipFile = new ZipFile();
         /** @noinspection PhpParamsInspection */
@@ -1304,7 +1304,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddFromStreamEmptyEntryName()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Empty entry name');
+        $this->expectException(InvalidArgumentException::class, 'Empty entry name');
 
         $handle = fopen(__FILE__, 'rb');
 
@@ -1317,7 +1317,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddFromStreamUnsupportedMethod()
     {
-        $this->setExpectedException(
+        $this->expectException(
             ZipUnsupportMethodException::class,
             'Compression method 99 (AES Encryption) is not supported.'
         );
@@ -1367,7 +1367,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddFileNullFileName()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Filename is null');
+        $this->expectException(InvalidArgumentException::class, 'Filename is null');
 
         $zipFile = new ZipFile();
         $zipFile->addFile(null);
@@ -1378,7 +1378,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddFileCantExists()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'File path/to/file is not readable');
+        $this->expectException(InvalidArgumentException::class, 'File path/to/file is not readable');
 
         $zipFile = new ZipFile();
         $zipFile->addFile('path/to/file');
@@ -1389,7 +1389,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddFileUnsupportedMethod()
     {
-        $this->setExpectedException(
+        $this->expectException(
             ZipUnsupportMethodException::class,
             'Compression method 99 (AES Encryption) is not supported.'
         );
@@ -1412,7 +1412,7 @@ class ZipFileTest extends ZipTestCase
             return;
         }
 
-        $this->setExpectedException(InvalidArgumentException::class, 'is not readable');
+        $this->expectException(InvalidArgumentException::class, 'is not readable');
 
         static::assertNotFalse(file_put_contents($this->outputFilename, ''));
         static::assertTrue(chmod($this->outputFilename, 0244));
@@ -1426,7 +1426,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddDirNullDirname()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Input dir is null');
+        $this->expectException(InvalidArgumentException::class, 'Input dir is null');
 
         $zipFile = new ZipFile();
         $zipFile->addDir(null);
@@ -1437,7 +1437,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddDirEmptyDirname()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'The input directory is not specified');
+        $this->expectException(InvalidArgumentException::class, 'The input directory is not specified');
 
         $zipFile = new ZipFile();
         $zipFile->addDir('');
@@ -1448,7 +1448,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddDirCantExists()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'does not exist');
+        $this->expectException(InvalidArgumentException::class, 'does not exist');
 
         $zipFile = new ZipFile();
         $zipFile->addDir(uniqid('', false));
@@ -1459,7 +1459,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddDirRecursiveNullDirname()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Input dir is null');
+        $this->expectException(InvalidArgumentException::class, 'Input dir is null');
 
         $zipFile = new ZipFile();
         $zipFile->addDirRecursive(null);
@@ -1470,7 +1470,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddDirRecursiveEmptyDirname()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'The input directory is not specified');
+        $this->expectException(InvalidArgumentException::class, 'The input directory is not specified');
 
         $zipFile = new ZipFile();
         $zipFile->addDirRecursive('');
@@ -1481,7 +1481,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddDirRecursiveCantExists()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'does not exist');
+        $this->expectException(InvalidArgumentException::class, 'does not exist');
 
         $zipFile = new ZipFile();
         $zipFile->addDirRecursive(uniqid('', false));
@@ -1492,7 +1492,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddFilesFromGlobNull()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Input dir is null');
+        $this->expectException(InvalidArgumentException::class, 'Input dir is null');
 
         $zipFile = new ZipFile();
         $zipFile->addFilesFromGlob(null, '*.png');
@@ -1503,7 +1503,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddFilesFromGlobEmpty()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'The input directory is not specified');
+        $this->expectException(InvalidArgumentException::class, 'The input directory is not specified');
 
         $zipFile = new ZipFile();
         $zipFile->addFilesFromGlob('', '*.png');
@@ -1514,7 +1514,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddFilesFromGlobCantExists()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'does not exist');
+        $this->expectException(InvalidArgumentException::class, 'does not exist');
 
         $zipFile = new ZipFile();
         $zipFile->addFilesFromGlob('path/to/path', '*.png');
@@ -1525,7 +1525,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddFilesFromGlobNullPattern()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'The glob pattern is not specified');
+        $this->expectException(InvalidArgumentException::class, 'The glob pattern is not specified');
 
         $zipFile = new ZipFile();
         $zipFile->addFilesFromGlob(__DIR__, null);
@@ -1536,7 +1536,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddFilesFromGlobEmptyPattern()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'The glob pattern is not specified');
+        $this->expectException(InvalidArgumentException::class, 'The glob pattern is not specified');
 
         $zipFile = new ZipFile();
         $zipFile->addFilesFromGlob(__DIR__, '');
@@ -1547,7 +1547,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddFilesFromGlobRecursiveNull()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Input dir is null');
+        $this->expectException(InvalidArgumentException::class, 'Input dir is null');
 
         $zipFile = new ZipFile();
         $zipFile->addFilesFromGlobRecursive(null, '*.png');
@@ -1558,7 +1558,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddFilesFromGlobRecursiveEmpty()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'The input directory is not specified');
+        $this->expectException(InvalidArgumentException::class, 'The input directory is not specified');
 
         $zipFile = new ZipFile();
         $zipFile->addFilesFromGlobRecursive('', '*.png');
@@ -1569,7 +1569,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddFilesFromGlobRecursiveCantExists()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'does not exist');
+        $this->expectException(InvalidArgumentException::class, 'does not exist');
 
         $zipFile = new ZipFile();
         $zipFile->addFilesFromGlobRecursive('path/to/path', '*.png');
@@ -1580,7 +1580,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddFilesFromGlobRecursiveNullPattern()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'The glob pattern is not specified');
+        $this->expectException(InvalidArgumentException::class, 'The glob pattern is not specified');
 
         $zipFile = new ZipFile();
         $zipFile->addFilesFromGlobRecursive(__DIR__, null);
@@ -1591,7 +1591,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddFilesFromGlobRecursiveEmptyPattern()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'The glob pattern is not specified');
+        $this->expectException(InvalidArgumentException::class, 'The glob pattern is not specified');
 
         $zipFile = new ZipFile();
         $zipFile->addFilesFromGlobRecursive(__DIR__, '');
@@ -1602,7 +1602,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddFilesFromRegexDirectoryNull()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'The input directory is not specified');
+        $this->expectException(InvalidArgumentException::class, 'The input directory is not specified');
 
         $zipFile = new ZipFile();
         $zipFile->addFilesFromRegex(null, '~\.png$~i');
@@ -1613,7 +1613,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddFilesFromRegexDirectoryEmpty()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'The input directory is not specified');
+        $this->expectException(InvalidArgumentException::class, 'The input directory is not specified');
 
         $zipFile = new ZipFile();
         $zipFile->addFilesFromRegex('', '~\.png$~i');
@@ -1624,7 +1624,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddFilesFromRegexCantExists()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'does not exist');
+        $this->expectException(InvalidArgumentException::class, 'does not exist');
 
         $zipFile = new ZipFile();
         $zipFile->addFilesFromRegex('path/to/path', '~\.png$~i');
@@ -1635,7 +1635,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddFilesFromRegexNullPattern()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'The regex pattern is not specified');
+        $this->expectException(InvalidArgumentException::class, 'The regex pattern is not specified');
 
         $zipFile = new ZipFile();
         $zipFile->addFilesFromRegex(__DIR__, null);
@@ -1646,7 +1646,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddFilesFromRegexEmptyPattern()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'The regex pattern is not specified');
+        $this->expectException(InvalidArgumentException::class, 'The regex pattern is not specified');
 
         $zipFile = new ZipFile();
         $zipFile->addFilesFromRegex(__DIR__, '');
@@ -1657,7 +1657,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddFilesFromRegexRecursiveDirectoryNull()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'The input directory is not specified');
+        $this->expectException(InvalidArgumentException::class, 'The input directory is not specified');
 
         $zipFile = new ZipFile();
         $zipFile->addFilesFromRegexRecursive(null, '~\.png$~i');
@@ -1668,7 +1668,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddFilesFromRegexRecursiveEmpty()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'The input directory is not specified');
+        $this->expectException(InvalidArgumentException::class, 'The input directory is not specified');
 
         $zipFile = new ZipFile();
         $zipFile->addFilesFromRegexRecursive('', '~\.png$~i');
@@ -1679,7 +1679,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddFilesFromRegexRecursiveCantExists()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'does not exist');
+        $this->expectException(InvalidArgumentException::class, 'does not exist');
 
         $zipFile = new ZipFile();
         $zipFile->addFilesFromGlobRecursive('path/to/path', '~\.png$~i');
@@ -1690,7 +1690,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddFilesFromRegexRecursiveNullPattern()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'The regex pattern is not specified');
+        $this->expectException(InvalidArgumentException::class, 'The regex pattern is not specified');
 
         $zipFile = new ZipFile();
         $zipFile->addFilesFromRegexRecursive(__DIR__, null);
@@ -1701,7 +1701,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddFilesFromRegexRecursiveEmptyPattern()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'The regex pattern is not specified');
+        $this->expectException(InvalidArgumentException::class, 'The regex pattern is not specified');
 
         $zipFile = new ZipFile();
         $zipFile->addFilesFromRegexRecursive(__DIR__, '');
@@ -1712,7 +1712,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testSaveAsStreamBadStream()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'handle is not resource');
+        $this->expectException(InvalidArgumentException::class, 'handle is not resource');
 
         $zipFile = new ZipFile();
         /** @noinspection PhpParamsInspection */
@@ -1894,7 +1894,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddEmptyDirNullName()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Entry name is null');
+        $this->expectException(InvalidArgumentException::class, 'Entry name is null');
 
         $zipFile = new ZipFile();
         $zipFile->addEmptyDir(null);
@@ -1905,7 +1905,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testAddEmptyDirEmptyName()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Empty entry name');
+        $this->expectException(InvalidArgumentException::class, 'Empty entry name');
 
         $zipFile = new ZipFile();
         $zipFile->addEmptyDir('');
@@ -1913,7 +1913,7 @@ class ZipFileTest extends ZipTestCase
 
     public function testNotFoundEntry()
     {
-        $this->setExpectedException(ZipEntryNotFoundException::class, '"bad entry name"');
+        $this->expectException(ZipEntryNotFoundException::class, '"bad entry name"');
 
         $zipFile = new ZipFile();
         $zipFile['bad entry name'];
@@ -1960,7 +1960,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testRewriteString()
     {
-        $this->setExpectedException(ZipException::class, 'Overwrite is only supported for open local files');
+        $this->expectException(ZipException::class, 'Overwrite is only supported for open local files');
 
         $zipFile = new ZipFile();
         $zipFile['file'] = 'content';
@@ -1986,7 +1986,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testRewriteNullStream()
     {
-        $this->setExpectedException(ZipException::class, 'input stream is null');
+        $this->expectException(ZipException::class, 'input stream is null');
 
         $zipFile = new ZipFile();
         $zipFile->rewrite();
@@ -2177,7 +2177,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testInvalidCompressionLevel()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Invalid compression level');
+        $this->expectException(InvalidArgumentException::class, 'Invalid compression level');
 
         $zipFile = new ZipFile();
         $zipFile->addFromString('file', 'content');
@@ -2189,7 +2189,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testInvalidCompressionLevelEntry()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Invalid compression level');
+        $this->expectException(InvalidArgumentException::class, 'Invalid compression level');
 
         $zipFile = new ZipFile();
         $zipFile->addFromString('file', 'content');
@@ -2249,7 +2249,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testInvalidCompressionMethodEntry()
     {
-        $this->setExpectedException(
+        $this->expectException(
             ZipUnsupportMethodException::class,
             'Compression method 99 (AES Encryption) is not supported.'
         );
@@ -2428,7 +2428,7 @@ class ZipFileTest extends ZipTestCase
     {
         for ($i = 0; $i < 2; $i++) {
             $fp = $zipFile->getEntryStream($entryName);
-            static::assertInternalType('resource', $fp);
+            static::assertIsResource($fp);
             static::assertSame(stream_get_contents($fp), $contents);
             fclose($fp);
         }
@@ -2566,7 +2566,7 @@ class ZipFileTest extends ZipTestCase
      */
     public function testNoData()
     {
-        $this->setExpectedException(ZipException::class, 'No data for zip entry file');
+        $this->expectException(ZipException::class, 'No data for zip entry file');
 
         $entryName = 'file';
 

--- a/tests/ZipInfoTest.php
+++ b/tests/ZipInfoTest.php
@@ -54,7 +54,7 @@ final class ZipInfoTest extends ZipTestCase
      */
     public function testZipInfoEntryNotFound()
     {
-        $this->setExpectedException(
+        $this->expectException(
             ZipEntryNotFoundException::class,
             'Zip Entry "unknown.name" was not found in the archive.'
         );

--- a/tests/ZipMatcherTest.php
+++ b/tests/ZipMatcherTest.php
@@ -24,7 +24,7 @@ class ZipMatcherTest extends TestCase
         $matcher = $zipFile->matcher();
         static::assertInstanceOf(ZipEntryMatcher::class, $matcher);
 
-        static::assertInternalType('array', $matcher->getMatches());
+        static::assertIsArray($matcher->getMatches());
         static::assertCount(0, $matcher);
 
         $matcher->add(1)->add(10)->add(20);

--- a/tests/ZipPasswordTest.php
+++ b/tests/ZipPasswordTest.php
@@ -31,7 +31,7 @@ class ZipPasswordTest extends ZipFileSetTestCase
     public function testSetPassword()
     {
         if (\PHP_INT_SIZE === 4) { // php 32 bit
-            $this->setExpectedException(
+            $this->expectException(
                 RuntimeException::class,
                 'Traditional PKWARE Encryption is not supported in 32-bit PHP.'
             );
@@ -132,7 +132,7 @@ class ZipPasswordTest extends ZipFileSetTestCase
     public function testTraditionalEncryption()
     {
         if (\PHP_INT_SIZE === 4) { // php 32 bit
-            $this->setExpectedException(
+            $this->expectException(
                 RuntimeException::class,
                 'Traditional PKWARE Encryption is not supported in 32-bit PHP.'
             );
@@ -215,7 +215,7 @@ class ZipPasswordTest extends ZipFileSetTestCase
     public function testEncryptionEntries()
     {
         if (\PHP_INT_SIZE === 4) { // php 32 bit
-            $this->setExpectedException(
+            $this->expectException(
                 RuntimeException::class,
                 'Traditional PKWARE Encryption is not supported in 32-bit PHP.'
             );
@@ -247,11 +247,11 @@ class ZipPasswordTest extends ZipFileSetTestCase
 
         $info = $zip->getEntryInfo('.hidden');
         static::assertTrue($info->isEncrypted());
-        static::assertContains('Traditional PKWARE encryption', $info->getEncryptionMethodName());
+        static::assertStringContainsString('Traditional PKWARE encryption', $info->getEncryptionMethodName());
 
         $info = $zip->getEntryInfo('text file.txt');
         static::assertTrue($info->isEncrypted());
-        static::assertContains('WinZip AES', $info->getEncryptionMethodName());
+        static::assertStringContainsString('WinZip AES', $info->getEncryptionMethodName());
 
         static::assertFalse($zip->getEntryInfo('Текстовый документ.txt')->isEncrypted());
         static::assertFalse($zip->getEntryInfo('empty dir/')->isEncrypted());
@@ -266,7 +266,7 @@ class ZipPasswordTest extends ZipFileSetTestCase
     public function testEncryptionEntriesWithDefaultPassword()
     {
         if (\PHP_INT_SIZE === 4) { // php 32 bit
-            $this->setExpectedException(
+            $this->expectException(
                 RuntimeException::class,
                 'Traditional PKWARE Encryption is not supported in 32-bit PHP.'
             );
@@ -301,15 +301,15 @@ class ZipPasswordTest extends ZipFileSetTestCase
 
         $info = $zip->getEntryInfo('.hidden');
         static::assertTrue($info->isEncrypted());
-        static::assertContains('Traditional PKWARE encryption', $info->getEncryptionMethodName());
+        static::assertStringContainsString('Traditional PKWARE encryption', $info->getEncryptionMethodName());
 
         $info = $zip->getEntryInfo('text file.txt');
         static::assertTrue($info->isEncrypted());
-        static::assertContains('WinZip AES', $info->getEncryptionMethodName());
+        static::assertStringContainsString('WinZip AES', $info->getEncryptionMethodName());
 
         $info = $zip->getEntryInfo('Текстовый документ.txt');
         static::assertTrue($info->isEncrypted());
-        static::assertContains('WinZip AES', $info->getEncryptionMethodName());
+        static::assertStringContainsString('WinZip AES', $info->getEncryptionMethodName());
 
         static::assertFalse($zip->getEntryInfo('empty dir/')->isEncrypted());
 
@@ -321,7 +321,7 @@ class ZipPasswordTest extends ZipFileSetTestCase
      */
     public function testSetEncryptionMethodInvalid()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Encryption method 9999 is not supported.');
+        $this->expectException(InvalidArgumentException::class, 'Encryption method 9999 is not supported.');
 
         $zipFile = new ZipFile();
         $encryptionMethod = 9999;
@@ -369,7 +369,7 @@ class ZipPasswordTest extends ZipFileSetTestCase
      */
     public function testInvalidEncryptionMethodEntry()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Encryption method 99 is not supported.');
+        $this->expectException(InvalidArgumentException::class, 'Encryption method 99 is not supported.');
 
         $zipFile = new ZipFile();
         $zipFile->addFromString('file', 'content', ZipCompressionMethod::STORED);
@@ -471,7 +471,7 @@ class ZipPasswordTest extends ZipFileSetTestCase
         foreach ($zipFile as $name => $contents) {
             static::assertNotEmpty($name);
             static::assertNotEmpty($contents);
-            static::assertContains('test contents', $contents);
+            static::assertStringContainsString('test contents', $contents);
             static::assertSame($zipFile2[$name], $contents);
         }
         $zipFile2->close();

--- a/tests/ZipStreamOpenTest.php
+++ b/tests/ZipStreamOpenTest.php
@@ -36,13 +36,13 @@ class ZipStreamOpenTest extends TestCase
         }
 
         if ($exceptionClass !== null) {
-            $this->setExpectedException(
+            $this->expectException(
                 $exceptionClass,
                 $exceptionMessage
             );
         }
 
-        static::assertInternalType('resource', $resource);
+        static::assertIsResource($resource);
 
         $zipFile = new ZipFile();
         $zipFile->openFromStream($resource);

--- a/tests/ZipTestCase.php
+++ b/tests/ZipTestCase.php
@@ -22,7 +22,7 @@ abstract class ZipTestCase extends TestCase
      *
      * @noinspection PhpMissingParentCallCommonInspection
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $id = uniqid('phpzip', false);
         $tempDir = sys_get_temp_dir() . \DIRECTORY_SEPARATOR . 'phpunit-phpzip';
@@ -37,7 +37,7 @@ abstract class ZipTestCase extends TestCase
     /**
      * After test.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no

* Migrate CI from Travis to Github Actions because Travis CI is no longer providing CI minutes for open source projects.
* Add phpunit 8 and 9 which supports PHP 7.2+: https://phpunit.de/supported-versions.html
* Drop support for PHP less than 7.2
* Update tests
  * Change $this->setExpectedException(...) to $this->expectException(...)
  * Add : void as return type
  * Solve other phpunit deprecation warnings
