### PR TITLE
Handle directory symlinks properly.

### DIFF
--- a/src/Model/ZipEntry.php
+++ b/src/Model/ZipEntry.php
@@ -1447,7 +1447,7 @@ class ZipEntry
             return $mode;
         }
 
-        return $this->isDirectory ? 040755 : 0100644;
+        return $this->isDirectory && !$this->isUnixSymlink() ? 040755 : 0100644;
     }
 
     /**

--- a/src/Util/FilesUtil.php
+++ b/src/Util/FilesUtil.php
@@ -45,7 +45,7 @@ final class FilesUtil
 
         /** @var \SplFileInfo $fileInfo */
         foreach ($files as $fileInfo) {
-            $function = ($fileInfo->isDir() ? 'rmdir' : 'unlink');
+            $function = ($fileInfo->isDir() && !$fileInfo->isLink() ? 'rmdir' : 'unlink');
             $function($fileInfo->getPathname());
         }
         @rmdir($dir);

--- a/src/ZipFile.php
+++ b/src/ZipFile.php
@@ -688,7 +688,7 @@ class ZipFile implements ZipFileInterface
         }
 
         $entryName = $this->normalizeEntryName($entryName);
-        $entryName = $file->isDir() ? rtrim($entryName, '/\\') . '/' : $entryName;
+        $entryName = $file->isDir() && !$file->isLink() ? rtrim($entryName, '/\\') . '/' : $entryName;
 
         $zipEntry = new ZipEntry($entryName);
         $zipEntry->setCreatedOS(ZipPlatform::OS_UNIX);
@@ -706,6 +706,7 @@ class ZipFile implements ZipFileInterface
             $zipEntry->setCompressedSize($lengthLinkTarget);
             $zipEntry->setCrc(crc32($linkTarget));
             $filePerms |= UnixStat::UNX_IFLNK;
+            $filePerms &= ~UnixStat::UNX_IFDIR;
 
             $zipData = new ZipNewData($zipEntry, $linkTarget);
         } elseif ($file->isFile()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no

As symlinks are special files in the zip, symlinks to directories must be treated like files and must loose their directory attribute. Those zip entries may not have `/` as a suffix, as `ZipEntry->setName()` would mark them as a directory.

Note that PHP treats symlinks as files, so `FilesUtil::removeDir()` had to be modified too for the test to pass.
```
$ php -r 'chdir(exec("mktemp -d")); mkdir("one"); symlink("./one", "symlinked"); rmdir("one"); rmdir("symlinked"); unlink("symlinked");'
```
Produces: _PHP Warning:  rmdir(symlinked): Not a directory in Command line code on line 1_
But `unlink()` succeeds.