### PR TITLE
Remove ftruncate for saveAsStream

### DIFF
--- a/src/ZipFile.php
+++ b/src/ZipFile.php
@@ -1537,7 +1537,7 @@ class ZipFile implements \Countable, \ArrayAccess, \Iterator
         if (!\is_resource($handle)) {
             throw new InvalidArgumentException('handle is not resource');
         }
-        ftruncate($handle, 0);
+
         $this->writeZipToStream($handle);
         fclose($handle);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no

This PR removed the `ftruncate` call for the `saveAsStream` method. Reasoning is that we use the S3 stream wrapper, and would like to write the ZIP to a s3 file. When `ftruncate` is called on s3 streams, the error is thrown that S3 doesn't support that. 

For these cases, where it's always written to a stream, I don't see the need for this truncate method, but I might be mistaken. Open for other improvements here.
